### PR TITLE
Change external dependencies pycryptodome to Crypto

### DIFF
--- a/payment_paybox/__manifest__.py
+++ b/payment_paybox/__manifest__.py
@@ -17,7 +17,7 @@
     #
     'external_dependencies': {
         'python': [
-            'pycryptodome'
+            'Crypto'
         ]
     },
     # any module necessary for this one to work correctly. Either because this module uses features

--- a/setup/payment_paybox/setup.py
+++ b/setup/payment_paybox/setup.py
@@ -2,11 +2,5 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['setuptools-odoo'],
-    odoo_addon={
-        'external_dependencies_override': {
-            'python': {
-                'Crypto': 'pycryptodome',
-            },
-        },
-    },
+    odoo_addon=True,
 )


### PR DESCRIPTION
La dépendance pycryptodome n'est pas correctement détectée par le module.